### PR TITLE
DirectIP SBD support

### DIFF
--- a/python/Iridium9602.py
+++ b/python/Iridium9602.py
@@ -11,6 +11,10 @@ from imap_stuff import checkMessages
 import socket
 import struct
 import asyncore
+from collections import deque
+from sbd_packets import assemble_mo_directip_packet
+from sbd_packets import parse_mt_directip_packet
+from sbd_packets import assemble_mt_directip_response
 
 AVERAGE_SBDIX_DELAY = 1     #TODO: implement randomness, average is ~30s
 STDEV_SBDIX_DELAY = 1 
@@ -69,7 +73,7 @@ email_enabled = False
 ip_enabled = False
 http_post_enabled = False
 
-
+mt_messages = deque()
 
 def send_mo_email():
     global lat
@@ -149,6 +153,7 @@ def sbdix():
     global mt_buffer
     global mo_ip
     global mo_port
+    global mt_set
 
     has_incoming_msg = False
     received_msg = 0
@@ -181,18 +186,23 @@ def sbdix():
                 received_msg_size = 0
     
         elif ip_enabled:
-            s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
             if mo_set and not mo_buffer == "":
+                s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
                 momsn += 1
                 try:
                     s.connect((mo_ip, mo_port))
-                    s.send(assemble_mo_directip_packet())
+                    s.send(assemble_mo_directip_packet(imei, momsn, mtmsn, mo_buffer))
                     s.close()
                 except socket.error as msg:
                     print "Failed to open {}:{}".format(mo_ip, mo_port)
                     s.close()                
                 mo_set = False
-            received_msg_size = len(mt_buffer)
+            if len(mt_messages) is not 0:
+                mtmsn += 1
+                mt_set = True
+                mt_buffer = mt_messages.popleft()
+                received_msg = mt_set
+                received_msg_size = len(mt_buffer)
 
     #TODO: generate result output
     if success: rpt = 0
@@ -256,7 +266,7 @@ def read_binary():
     ser.write("%s%s%s%s%s" % (chr(len_msb), chr(len_lsb), mt_buffer,chr(checksum_msb),chr(checksum_lsb)) )
     print "\r\n%s%s%s%s%s" % (chr(len_msb), chr(len_lsb), mt_buffer,chr(checksum_msb),chr(checksum_lsb))
     print checksum_msb, checksum_lsb, len_msb, len_lsb, mt_buffer
-    send_ok()
+    # send_ok()
     
 
 def send_ok():
@@ -431,6 +441,7 @@ def write_binary_start(cmd,start_index):
         send_error()
 
 def parse_cmd(cmd):
+    global echo
     #get string up to newline or '=' 
     index = cmd.find('=')
     if index == -1:
@@ -465,6 +476,9 @@ def parse_cmd(cmd):
     elif cmd_type == 'at+sbdgw'     : which_gateway()
     elif cmd_type == 'at-msstm'     : get_system_time()
     elif cmd_type == 'at+sbdmta'    : set_ring_indicator(cmd,index + 1)
+    elif cmd_type == 'ate0' or cmd_type == 'ate': 
+        echo = False
+        do_ok()
     elif cmd_type == 'ate1'    : do_ok()
     elif cmd_type == 'at&d0'    : do_ok()
     elif cmd_type == 'at&k0'    : do_ok()
@@ -474,124 +488,6 @@ def parse_cmd(cmd):
 def open_port(dev,baudrate):
     ser = serial.Serial(dev, 19200, timeout=.1, parity=serial.PARITY_NONE)
     return ser
-
-
-
-
-def assemble_mo_directip_packet():
-    global imei
-    global momsn
-    global mtmsn
-    global mo_buffer
-
-    # ==== MO HEADER ====
-    # MO Header IEI           char               0x01
-    # MO Header Length        unsigned short
-    # CDR Reference (Auto ID) unsigned integer
-    # IMEI                    char[] (15 bytes)
-    # Session Status          unsigned char
-    # MOMSN                   unsigned short
-    # MTMSN                   unsigned short
-    # Time of Session         unsigned integer
-    header_fmt = "!bHI15sBHHI"
-    header_iei = 0x01
-    # header_length does not include iei and length fields
-    header_length = struct.calcsize(header_fmt) - struct.calcsize('!bH')
-    cdr_ref = random.getrandbits(32)
-    session_status = 0
-    header = struct.pack(header_fmt, header_iei, header_length, cdr_ref, str(imei), session_status, momsn, mtmsn, int(time.time()))
-
-    # ==== MO PAYLOAD ====
-    # MO Payload IEI         char               0x02
-    # MO Payload Length      unsigned short    
-    # MO Payload             char 
-    payload_iei = 0x02
-    payload_length = min(len(mo_buffer), 1960)
-    payload = struct.pack('!bH' + str(payload_length) + 's', payload_iei, payload_length, mo_buffer)
-
-    protocol_rev_no = 1    
-    overall_msg_length = len(header) + len(payload)    
-    preheader = struct.pack('!bH', protocol_rev_no, overall_msg_length)
-    return preheader + header + payload
-
-def parse_mt_directip_packet(buffer):
-    global mt_buffer
-    global mtmsn
-
-    parse_offset = 0
-    preheader_fmt = '!bH'
-    ie_header_fmt = '!bH'
-    preheader = struct.unpack_from(preheader_fmt, buffer, parse_offset)
-    parse_offset += struct.calcsize(preheader_fmt)
-
-    header_iei = 0x41
-    payload_iei = 0x42
-    prio_iei = 0x46
-    header = None
-    payload = None
-
-    while parse_offset + struct.calcsize(ie_header_fmt) < len(buffer):
-        ie_header = struct.unpack_from(ie_header_fmt, buffer, parse_offset)
-        print 'IE Header: ' + str(ie_header)
-        parse_offset += struct.calcsize(ie_header_fmt)
-
-        if ie_header[0] == header_iei:
-            # ==== MT HEADER ====
-            # MT Header IEI                char            0x41
-            # MT Header Length             unsigned short
-            # Unique Client Message ID     unsigned int
-            # IMEI (User ID)               char[] (15 bytes)
-            # MT Disposition Flags char    unsigned short
-            header_fmt = '!I15sH'
-            header = struct.unpack_from(header_fmt, buffer, parse_offset)
-            print 'Header: ' + str(header)
-        elif ie_header[0] == payload_iei:
-            # ==== MT PAYLOAD ====
-            # MO Payload IEI         char               2
-            # MO Payload Length      unsigned short    
-            # MO Payload             char 
-            payload_fmt = str(ie_header[1]) + 's'
-            payload = struct.unpack_from(payload_fmt, buffer, parse_offset)
-            print 'Payload: ' + str(payload)
-            mt_buffer = payload[0]
-            mtmsn += 1
-            mt_set = True
-        else:
-            print 'Unknown IEI: %x'.format(ie_header[0])
-            
-        parse_offset += ie_header[1]
-    return (header, payload)
-
-def assemble_mt_directip_response(mt_packet):
-    confirm_iei = 0x44
-    confirm_fmt = "!bHI15sIh"
-    confirm_length = struct.calcsize(confirm_fmt) - struct.calcsize('!bH')
-    session_status = 0
-    client_id = 0
-    imei = '0'*15
-    if mt_packet[0] is not None:
-        print mt_packet
-        session_status = 1 # 1 message queued
-        client_id = mt_packet[0][0]
-        imei = mt_packet[0][1]
-    else:
-        session_status = -7 # violation of MT DirectIP protocol error
-
-
-    # MT Confirmation Message IEI
-    # MT Confirmation Message Length
-    # Unique Client Message ID
-    # IMEI (User ID)
-    # Auto ID Reference
-    # MT Message Status
-    auto_id = random.getrandbits(32)
-    confirm = struct.pack(confirm_fmt, confirm_iei, confirm_length, client_id, imei, auto_id, session_status)
-    
-    protocol_rev_no = 1    
-    overall_msg_length = len(confirm)
-    preheader = struct.pack('!bH', protocol_rev_no, overall_msg_length)
-    return preheader + confirm
-
 
 class MobileTerminatedHandler(asyncore.dispatcher_with_send):
     def __init__(self, sock, addr):
@@ -604,6 +500,8 @@ class MobileTerminatedHandler(asyncore.dispatcher_with_send):
         self.preheader_size = struct.calcsize(self.preheader_fmt)
 
     def handle_read(self):
+        global mt_messages
+
         if len(self.data) < self.preheader_size:
             self.data += self.recv(self.preheader_size)
             preheader = struct.unpack(self.preheader_fmt, self.data)
@@ -617,11 +515,11 @@ class MobileTerminatedHandler(asyncore.dispatcher_with_send):
         if len(self.data) >= self.msg_length:
             mt_packet = None
             try: 
-                mt_packet = parse_mt_directip_packet(self.data)
+                mt_packet = parse_mt_directip_packet(self.data, mt_messages)
             except:
                 print 'MT Handler: Invalid message'
             # response message
-            self.send(assemble_mt_directip_response(mt_packet))
+            self.send(assemble_mt_directip_response(mt_packet, mt_messages))
             self.handle_close()
 
     def handle_close(self):
@@ -651,6 +549,8 @@ class MobileTerminatedServer(asyncore.dispatcher):
             print "MT Handler: Unexpected error:", sys.exc_info()[0]
 
     
+
+
 def main():
     
     global ser
@@ -673,11 +573,8 @@ def main():
     global mo_port
     global mt_port
 
-    # try:
-    #     parse_mt_directip_packet(("010061420046" + "00" * 70 + "4100154D7367313330303033343031303132333435300000").decode('hex'))
-    # except:
-    #     print 'Could not parse MT packet'
-    #     quit()
+    global echo
+
 
     parser = OptionParser()
     parser.add_option("-d", "--dev", dest="dev", action="store", help="tty dev(ex. '/dev/ttyUSB0'", metavar="DEV")
@@ -692,6 +589,8 @@ def main():
     parser.add_option("-m", "--mode", dest="mode", action="store", help="Mode: EMAIL,HTTP_POST,IP,NONE", default="NONE", metavar="MODE")
 
     (options, args) = parser.parse_args()
+
+    mt_port = int(options.mt_port)
     
     #check for valid arguments
     if options.mode == "EMAIL":
@@ -722,9 +621,6 @@ def main():
 
     mo_ip = options.mo_ip
     mo_port = int(options.mo_port)
-
-
-    mt_port = options.mt_port
 
 
     now_get_checksum_first = False

--- a/python/Iridium9602.py
+++ b/python/Iridium9602.py
@@ -268,7 +268,7 @@ def read_binary():
     ser.write("%s%s%s%s%s" % (chr(len_msb), chr(len_lsb), mt_buffer,chr(checksum_msb),chr(checksum_lsb)) )
     print "\r\n%s%s%s%s%s" % (chr(len_msb), chr(len_lsb), mt_buffer,chr(checksum_msb),chr(checksum_lsb))
     print checksum_msb, checksum_lsb, len_msb, len_lsb, mt_buffer
-    # send_ok()
+    send_ok()
     
 
 def send_ok():
@@ -298,19 +298,19 @@ def clear_buffers(buffer):
         mo_buffer = ''
         mo_set = False
         ser.write('\r\n0\r\n')
-#        send_ok()
+        send_ok()
     elif buffer == 1:
         mt_buffer = ''
         mt_set = False
         ser.write('\r\n0\r\n')
-#        send_ok()
+        send_ok()
     elif buffer == 2:
         mt_buffer = ''
         mo_buffer = ''
         mo_set = False
         mt_set = False
         ser.write('\r\n0\r\n')
-#        send_ok()
+        send_ok()
     else:
         send_error()
     
@@ -681,14 +681,14 @@ def main():
                 if (checksum_first * 256 + checksum_second) == (binary_checksum & (2**16-1)):
                     print "Good binary checksum"
                     ser.write('\r\n0\r\n')
-                    #send_ok()
+                    send_ok()
                     mo_buffer = rx_buffer
                     rx_buffer = ''
                     mo_set = True
                 else:
                     print "Bad binary checksum"
                     ser.write('\r\n2\r\n')
-                    #send_ok()
+                    send_ok()
                     rx_buffer = ''
                     ser.write('\n')            
                 binary_checksum = 0

--- a/python/Iridium9602.py
+++ b/python/Iridium9602.py
@@ -202,6 +202,7 @@ def sbdix():
                 mtmsn += 1
                 mt_set = True
                 mt_buffer = mt_messages.popleft()
+                unread_msgs = len(mt_messages)
                 received_msg = mt_set
                 received_msg_size = len(mt_buffer)
 
@@ -588,6 +589,7 @@ def main():
     parser.add_option("--mo_port", dest="mo_port", action="store", help="Mobile-originated DirectIP server Port", metavar="MO_PORT", default=10801)
     parser.add_option("--mt_port", dest="mt_port", action="store", help="Mobile-terminated DirectIP server Port", metavar="MT_PORT", default=10800)
     parser.add_option("-m", "--mode", dest="mode", action="store", help="Mode: EMAIL,HTTP_POST,IP,NONE", default="NONE", metavar="MODE")
+    parser.add_option("-e", "--imei", dest="imei", action="store", help="IMEI for this modem", default="300234060379270", metavar="MODE")
 
     (options, args) = parser.parse_args()
 
@@ -622,7 +624,7 @@ def main():
 
     mo_ip = options.mo_ip
     mo_port = int(options.mo_port)
-
+    imei = options.imei
 
     now_get_checksum_first = False
     now_get_checksum_second = False

--- a/python/Iridium9602.py
+++ b/python/Iridium9602.py
@@ -1,3 +1,4 @@
+#!/usr/bin/python
 import serial
 #from serial.tools import list_ports
 import os
@@ -6,15 +7,15 @@ import io
 import time
 import random
 import sys
-from smtp_stuff import sendMail 
-from imap_stuff import checkMessages
+from virtual_iridium.smtp_stuff import sendMail 
+from virtual_iridium.imap_stuff import checkMessages
 import socket
 import struct
 import asyncore
 from collections import deque
-from sbd_packets import assemble_mo_directip_packet
-from sbd_packets import parse_mt_directip_packet
-from sbd_packets import assemble_mt_directip_response
+from virtual_iridium.sbd_packets import assemble_mo_directip_packet
+from virtual_iridium.sbd_packets import parse_mt_directip_packet
+from virtual_iridium.sbd_packets import assemble_mt_directip_response
 
 AVERAGE_SBDIX_DELAY = 1     #TODO: implement randomness, average is ~30s
 STDEV_SBDIX_DELAY = 1 

--- a/python/Iridium9602.py
+++ b/python/Iridium9602.py
@@ -1,5 +1,5 @@
 import serial
-from serial.tools import list_ports
+#from serial.tools import list_ports
 import os
 from optparse import OptionParser
 import io
@@ -108,22 +108,22 @@ Message is Attached.'\
     
     sendMail(subject, body, user, recipient, password, outgoing_server, attachment)
 
-def list_serial_ports():
-    # Windows
-    if os.name == 'nt':
-        # Scan for available ports.
-        available = []
-        for i in range(256):
-            try:
-                s = serial.Serial(i)
-                available.append('COM'+str(i + 1))
-                s.close()
-            except serial.SerialException:
-                pass
-        return available
-    else:
-        # Mac / Linux
-        return [port[0] for port in list_ports.comports()]
+# def list_serial_ports():
+#     # Windows
+#     if os.name == 'nt':
+#         # Scan for available ports.
+#         available = []
+#         for i in range(256):
+#             try:
+#                 s = serial.Serial(i)
+#                 available.append('COM'+str(i + 1))
+#                 s.close()
+#             except serial.SerialException:
+#                 pass
+#         return available
+#     else:
+#         # Mac / Linux
+#         return [port[0] for port in list_ports.comports()]
 
 def write_text(cmd,start_index):
     global mo_set
@@ -286,19 +286,19 @@ def clear_buffers(buffer):
         mo_buffer = ''
         mo_set = False
         ser.write('\r\n0\r\n')
-        send_ok()
+#        send_ok()
     elif buffer == 1:
         mt_buffer = ''
         mt_set = False
         ser.write('\r\n0\r\n')
-        send_ok()
+#        send_ok()
     elif buffer == 2:
         mt_buffer = ''
         mo_buffer = ''
         mo_set = False
         mt_set = False
         ser.write('\r\n0\r\n')
-        send_ok()
+#        send_ok()
     else:
         send_error()
     
@@ -424,6 +424,7 @@ def write_binary_start(cmd,start_index):
             send_ok()
             binary_rx_incoming_bytes = 0
         else:
+            print 'Ready to receive {} bytes'.format(binary_rx_incoming_bytes)
             send_ready()
             binary_rx = True
     except:
@@ -703,7 +704,7 @@ def main():
         print 'Not implemented yet'
         sys.exit()
     elif options.mode == "IP":
-        print 'Using IP mode with MO ({}:{}) and MT (0.0.0.0:{}) servers'.format(options.mo_ip, options.mo_port, options.mt_port)
+        print 'Using IP mode with MO ({}:{}) and MT (0.0.0.0:{}) servers'.format(options.mo_ip, int(options.mo_port), options.mt_port)
         server = MobileTerminatedServer('0.0.0.0', mt_port)
         print "Started MT Server on port {}".format(mt_port)
         sys.stdout.flush()
@@ -720,7 +721,9 @@ def main():
     password = options.passwd
 
     mo_ip = options.mo_ip
-    mo_port = options.mo_port
+    mo_port = int(options.mo_port)
+
+
     mt_port = options.mt_port
 
 
@@ -731,8 +734,8 @@ def main():
         ser = open_port(options.dev,19200)
     except:
         print "Could not open serial port.  Exiting."
-        print "FYI - Here's a list of ports on your system."
-        print list_serial_ports()
+#        print "FYI - Here's a list of ports on your system."
+#        print list_serial_ports()
         sys.exit()
     
     rx_buffer = ''
@@ -779,14 +782,14 @@ def main():
                 if (checksum_first * 256 + checksum_second) == (binary_checksum & (2**16-1)):
                     print "Good binary checksum"
                     ser.write('\r\n0\r\n')
-                    send_ok()
+                    #send_ok()
                     mo_buffer = rx_buffer
                     rx_buffer = ''
                     mo_set = True
                 else:
                     print "Bad binary checksum"
                     ser.write('\r\n2\r\n')
-                    send_ok()
+                    #send_ok()
                     rx_buffer = ''
                     ser.write('\n')            
                 binary_checksum = 0

--- a/python/iridium_mo_forward_server.py
+++ b/python/iridium_mo_forward_server.py
@@ -43,6 +43,8 @@ class ConditionalForwardHandler(asyncore.dispatcher_with_send):
             return
         elif self.sbd_write: # not line mode - raw data
             self.sbd_send_bytes(data)
+        elif data == "+++":
+            self.hayes_client.send(data)
         else: # line based Command data
             self.buf += data
             line_list = self.buf.split('\r')

--- a/python/iridium_mt_forward_server.py
+++ b/python/iridium_mt_forward_server.py
@@ -15,7 +15,7 @@ mt_address = '0.0.0.0'
 mt_port = 40002
 
 # maps imei to address and port
-forward_address = { "300234060379270" : ("127.0.0.1",40003) }
+forward_address = { "300234060379270" : ("127.0.0.1",40010), "300234060379271" : ("127.0.0.1",40011), "300234060379272" : ("127.0.0.1",40012), "300234060379273" : ("127.0.0.1",40013), "300234060379274" : ("127.0.0.1",40014) }
 
 class ConditionalForwardClient(asyncore.dispatcher_with_send):
 

--- a/python/iridium_mt_forward_server.py
+++ b/python/iridium_mt_forward_server.py
@@ -11,13 +11,13 @@ from collections import deque
 import struct
 
 # this script listens (binds) on this port
-mt_address = '0.0.0.0'
-mt_port = 40002
+mt_sbd_address = '0.0.0.0'
+mt_sbd_port = 40002
 
 # maps imei to address and port
 forward_address = { "300234060379270" : ("127.0.0.1",40010), "300234060379271" : ("127.0.0.1",40011), "300234060379272" : ("127.0.0.1",40012), "300234060379273" : ("127.0.0.1",40013), "300234060379274" : ("127.0.0.1",40014) }
 
-class ConditionalForwardClient(asyncore.dispatcher_with_send):
+class ConditionalSBDForwardClient(asyncore.dispatcher_with_send):
 
     def __init__(self, server, host, port):
         asyncore.dispatcher_with_send.__init__(self)
@@ -31,7 +31,7 @@ class ConditionalForwardClient(asyncore.dispatcher_with_send):
            self.server.send(data)
 
 
-class ConditionalForwardHandler(asyncore.dispatcher_with_send):
+class ConditionalSBDForwardHandler(asyncore.dispatcher_with_send):
 
     def __init__(self, sock, addr):
         asyncore.dispatcher_with_send.__init__(self, sock)
@@ -69,7 +69,7 @@ class ConditionalForwardHandler(asyncore.dispatcher_with_send):
             print 'Attempting to forward message for imei: {}' .format(imei)
 
             if forward_address.has_key(imei):
-                self.client = ConditionalForwardClient(self, forward_address[imei][0], forward_address[imei][1])
+                self.client = ConditionalSBDForwardClient(self, forward_address[imei][0], forward_address[imei][1])
                 self.client.send(self.data)
                 self.data = ''
             else:
@@ -84,7 +84,7 @@ class ConditionalForwardHandler(asyncore.dispatcher_with_send):
         self.close()
 
 
-class ConditionalForwardServer(asyncore.dispatcher):
+class ConditionalSBDForwardServer(asyncore.dispatcher):
 
     def __init__(self, host, port):
         asyncore.dispatcher.__init__(self)
@@ -100,16 +100,16 @@ class ConditionalForwardServer(asyncore.dispatcher):
             print 'Incoming connection from %s' % repr(addr)
             sys.stdout.flush()
         try:
-            handler = ConditionalForwardHandler(sock, addr)
+            handler = ConditionalSBDForwardHandler(sock, addr)
         except: 
             print "Unexpected error:", sys.exc_info()[0]
             
 import sys
 print "Iridium SBD Port forwarder starting up ..."
-print "Listening on port: %d" % mt_port
+print "Listening for SBD on port: %d" % mt_sbd_port
 
 
 sys.stdout.flush()
 
-server = ConditionalForwardServer(mt_address, mt_port)
+sbd_server = ConditionalSBDForwardServer(mt_sbd_address, mt_sbd_port)
 asyncore.loop()

--- a/python/iridium_rudics_shore_connection.py
+++ b/python/iridium_rudics_shore_connection.py
@@ -1,0 +1,88 @@
+#!/usr/bin/python
+from optparse import OptionParser
+import socket
+import time
+
+def close_hayes_socket(hayes_socket):
+    hayes_socket.send("+++");        
+    time.sleep(2)
+    hayes_socket.send("ATH\r\n");  
+
+
+def main():
+    parser = OptionParser()
+    parser.add_option("-a", "--hayes_address", dest="hayes_address", action="store", help="Hayes Simulator Address")
+    parser.add_option("-p", "--hayes_port", dest="hayes_port", action="store", help="Hayes Simulator Port")
+
+    parser.add_option("-A", "--shore_address", dest="shore_address", action="store", help="Shore driver Address")
+    parser.add_option("-P", "--shore_port", dest="shore_port", action="store", help="Shore driver Port")
+
+    (options, args) = parser.parse_args()
+    print options
+
+    connected = False
+    buffer_size = 1024
+
+    shore_socket = None;
+ 
+
+    hayes_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    hayes_socket.connect((options.hayes_address, int(options.hayes_port)))
+    hayes_socket.settimeout(0.1)
+    hayes_socket.send("OK")
+    while(1):
+        try:       
+            if connected:
+                try:
+                    shore_data = shore_socket.recv(buffer_size)
+                    if(len(shore_data) > 0):
+                        hayes_socket.send(shore_data)
+                    else:
+                        print "Zero read"
+                        connected = False
+                        close_hayes_socket(hayes_socket)
+                except socket.timeout:
+                    pass
+                except socket.error as e:
+                    print "Shore socket error: ",e
+                    connected = False
+                    close_hayes_socket(hayes_socket, connected)
+
+            data = hayes_socket.recv(buffer_size)
+            print data
+
+            if("NO CARRIER" in data):
+                print "Disconnected!"
+                connected = False
+                shore_socket.close()
+                
+            if connected and len(data) > 0:
+                try:
+                    print "To Shore: ",data.encode("hex")
+                    shore_socket.send(data)
+                except socket.timeout:
+                    print "Timeout sending data"
+                except socket.error as e:
+                    print "Shore socket error: ",e
+                    connected = False
+                    hayes_socket.send("+++");        
+                    time.sleep(2)
+                    hayes_socket.send("ATH\r\n");  
+                    
+            if(data.strip() == "RING"):
+                hayes_socket.send("ATA\r\n");        
+            elif("CONNECT" in data):
+                print "Connected!"
+                shore_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+                shore_socket.settimeout(0.1)
+                shore_socket.connect((options.shore_address, int(options.shore_port)))
+                connected = True
+
+        except socket.timeout:
+            time.sleep(0.01)
+        except socket.error as e:
+            print e
+
+
+if __name__ == '__main__':
+    main()

--- a/python/mo_forward_server.py
+++ b/python/mo_forward_server.py
@@ -1,0 +1,84 @@
+#!/usr/bin/python
+
+# splits traffic to Hayes Modem emulator and to an Iridium9602 simulator
+
+import asyncore
+import socket
+
+# this script listens (binds) on this port
+forward_address = '0.0.0.0'
+forward_port = 4002
+
+# connections that send "goby" as the first four characters gets
+# forwarded to a server listening on this server at this port
+hayes_server = "127.0.0.1"
+hayes_port = 4001
+
+# connections that send "~" as the first character gets
+# forwarded to a server listening on localhost at this port
+sbd_server = "127.0.0.1"
+sbd_port = 4003
+
+class ConditionalForwardClient(asyncore.dispatcher_with_send):
+
+    def __init__(self, server, host, port):
+        asyncore.dispatcher_with_send.__init__(self)
+        self.create_socket(socket.AF_INET, socket.SOCK_STREAM)
+        self.connect( (host, port) )
+        self.server = server
+           
+    def handle_read(self):
+        data = self.recv(64)
+        if data:
+           self.server.send(data)
+
+
+class ConditionalForwardHandler(asyncore.dispatcher_with_send):
+
+    def __init__(self, sock, addr):
+        asyncore.dispatcher_with_send.__init__(self, sock)
+        self.identified_protocol = False
+        self.sbd_client = None
+        self.hayes_client = None
+        self.addr = addr
+	self.initial_data = ""
+
+    def handle_read(self):
+	for line in self.makefile('r'):
+            print(line)
+
+    def handle_close(self):
+        print 'Connection closed from %s' % repr(self.addr)
+        sys.stdout.flush()
+        self.close()
+
+
+class ConditionalForwardServer(asyncore.dispatcher):
+
+    def __init__(self, host, port):
+        asyncore.dispatcher.__init__(self)
+        self.create_socket(socket.AF_INET, socket.SOCK_STREAM)
+        self.set_reuse_addr()
+        self.bind((host, port))
+        self.listen(5)
+
+    def handle_accept(self):
+        pair = self.accept()
+        if pair is not None:
+            sock, addr = pair
+            print 'Incoming connection from %s' % repr(addr)
+            sys.stdout.flush()
+        try:
+            handler = ConditionalForwardHandler(sock, addr)
+        except: 
+            print "Unexpected error:", sys.exc_info()[0]
+            
+import sys
+print "Iridium Port forwarder starting up ..."
+print "Listening on port: %d" % forward_port
+print "Connecting for Iridium9602 SBD on %s:%d" % (sbd_server, sbd_port)
+print "Connecting for Hayes (ATDuck) on %s:%d" % (hayes_server, hayes_port)
+sys.stdout.flush()
+
+server = ConditionalForwardServer(forward_address, forward_port)
+asyncore.loop()

--- a/python/mt_forward_server.py
+++ b/python/mt_forward_server.py
@@ -1,0 +1,112 @@
+#!/usr/bin/python
+
+# Handles incoming Iridium SBD traffic and port forwards as appropriate based on IMEI 
+# Used to allow you to run multiple Iridium9602 simulator instances that can be handled
+# by a single MT DirectIP server
+
+import asyncore
+import socket
+from sbd_packets import parse_mt_directip_packet
+from collections import deque
+import struct
+
+# this script listens (binds) on this port
+mt_address = '0.0.0.0'
+mt_port = 40002
+
+# maps imei to address and port
+forward_address = { "300234060379270" : ("127.0.0.1",40003) }
+
+class ConditionalForwardClient(asyncore.dispatcher_with_send):
+
+    def __init__(self, server, host, port):
+        asyncore.dispatcher_with_send.__init__(self)
+        self.create_socket(socket.AF_INET, socket.SOCK_STREAM)
+        self.connect( (host, port) )
+        self.server = server
+           
+    def handle_read(self):
+        data = self.recv(64)
+        if data:
+           self.server.send(data)
+
+
+class ConditionalForwardHandler(asyncore.dispatcher_with_send):
+
+    def __init__(self, sock, addr):
+        asyncore.dispatcher_with_send.__init__(self, sock)
+        self.identified_protocol = False
+        self.client = None
+        self.addr = addr 
+        self.data = ''
+        self.preheader_fmt = '!bH'
+        self.preheader_size = struct.calcsize(self.preheader_fmt)
+
+    def handle_read(self):
+        if len(self.data) < self.preheader_size:
+            self.data += self.recv(self.preheader_size)
+            preheader = struct.unpack(self.preheader_fmt, self.data)
+            self.msg_length = preheader[1]
+        else:
+            self.data += self.recv(self.msg_length)
+        
+        print self.msg_length
+        print self.data.encode("hex")
+            
+        if len(self.data) >= self.msg_length:
+            mt_packet = None
+            mt_messages = deque()
+            try: 
+                mt_packet = parse_mt_directip_packet(self.data, mt_messages)
+            except:
+                print 'MT Handler: Invalid message'
+                sys.stdout.flush()
+                
+            imei = mt_packet[0][1]
+                
+            print 'Attempting to forward message for imei: {}' .format(imei)
+
+            if forward_address.has_key(imei):
+                self.client = ConditionalForwardClient(self, forward_address[imei][0], forward_address[imei][1])
+                self.client.send(self.data)
+            else:
+                print 'No forwarding set up for imei: {}'.format(imei)
+                self.close()
+
+    def handle_close(self):
+        print 'Connection closed from %s' % repr(self.addr)
+        sys.stdout.flush()
+        if self.client is not None:
+            self.client.close()
+        self.close()
+
+
+class ConditionalForwardServer(asyncore.dispatcher):
+
+    def __init__(self, host, port):
+        asyncore.dispatcher.__init__(self)
+        self.create_socket(socket.AF_INET, socket.SOCK_STREAM)
+        self.set_reuse_addr()
+        self.bind((host, port))
+        self.listen(5)
+
+    def handle_accept(self):
+        pair = self.accept()
+        if pair is not None:
+            sock, addr = pair
+            print 'Incoming connection from %s' % repr(addr)
+            sys.stdout.flush()
+        try:
+            handler = ConditionalForwardHandler(sock, addr)
+        except: 
+            print "Unexpected error:", sys.exc_info()[0]
+            
+import sys
+print "Iridium SBD Port forwarder starting up ..."
+print "Listening on port: %d" % mt_port
+
+
+sys.stdout.flush()
+
+server = ConditionalForwardServer(mt_address, mt_port)
+asyncore.loop()

--- a/python/mt_forward_server.py
+++ b/python/mt_forward_server.py
@@ -6,7 +6,7 @@
 
 import asyncore
 import socket
-from sbd_packets import parse_mt_directip_packet
+from virtual_iridium.sbd_packets import parse_mt_directip_packet
 from collections import deque
 import struct
 

--- a/python/sbd_packets.py
+++ b/python/sbd_packets.py
@@ -1,0 +1,110 @@
+import struct
+import random
+import time
+
+def assemble_mo_directip_packet(imei, momsn, mtmsn, mo_buffer):
+
+    # ==== MO HEADER ====
+    # MO Header IEI           char               0x01
+    # MO Header Length        unsigned short
+    # CDR Reference (Auto ID) unsigned integer
+    # IMEI                    char[] (15 bytes)
+    # Session Status          unsigned char
+    # MOMSN                   unsigned short
+    # MTMSN                   unsigned short
+    # Time of Session         unsigned integer
+    header_fmt = "!bHI15sBHHI"
+    header_iei = 0x01
+    # header_length does not include iei and length fields
+    header_length = struct.calcsize(header_fmt) - struct.calcsize('!bH')
+    cdr_ref = random.getrandbits(32)
+    session_status = 0
+    header = struct.pack(header_fmt, header_iei, header_length, cdr_ref, str(imei), session_status, momsn, mtmsn, int(time.time()))
+
+    # ==== MO PAYLOAD ====
+    # MO Payload IEI         char               0x02
+    # MO Payload Length      unsigned short    
+    # MO Payload             char 
+    payload_iei = 0x02
+    payload_length = min(len(mo_buffer), 1960)
+    payload = struct.pack('!bH' + str(payload_length) + 's', payload_iei, payload_length, mo_buffer)
+
+    protocol_rev_no = 1    
+    overall_msg_length = len(header) + len(payload)    
+    preheader = struct.pack('!bH', protocol_rev_no, overall_msg_length)
+    return preheader + header + payload
+
+def parse_mt_directip_packet(buffer, mt_messages):
+
+    parse_offset = 0
+    preheader_fmt = '!bH'
+    ie_header_fmt = '!bH'
+    preheader = struct.unpack_from(preheader_fmt, buffer, parse_offset)
+    parse_offset += struct.calcsize(preheader_fmt)
+
+    header_iei = 0x41
+    payload_iei = 0x42
+    prio_iei = 0x46
+    header = None
+    payload = None
+
+    while parse_offset + struct.calcsize(ie_header_fmt) < len(buffer):
+        ie_header = struct.unpack_from(ie_header_fmt, buffer, parse_offset)
+        print 'IE Header: ' + str(ie_header)
+        parse_offset += struct.calcsize(ie_header_fmt)
+
+        if ie_header[0] == header_iei:
+            # ==== MT HEADER ====
+            # MT Header IEI                char            0x41
+            # MT Header Length             unsigned short
+            # Unique Client Message ID     unsigned int
+            # IMEI (User ID)               char[] (15 bytes)
+            # MT Disposition Flags char    unsigned short
+            header_fmt = '!I15sH'
+            header = struct.unpack_from(header_fmt, buffer, parse_offset)
+            print 'Header: ' + str(header)
+        elif ie_header[0] == payload_iei:
+            # ==== MT PAYLOAD ====
+            # MO Payload IEI         char               2
+            # MO Payload Length      unsigned short    
+            # MO Payload             char 
+            payload_fmt = str(ie_header[1]) + 's'
+            payload = struct.unpack_from(payload_fmt, buffer, parse_offset)
+            print 'Payload: ' + str(payload)
+            mt_messages.append(payload[0])
+        else:
+            print 'Unknown IEI: %x'.format(ie_header[0])
+            
+        parse_offset += ie_header[1]
+    return (header, payload)
+
+def assemble_mt_directip_response(mt_packet, mt_messages):
+
+    confirm_iei = 0x44
+    confirm_fmt = "!bHI15sIh"
+    confirm_length = struct.calcsize(confirm_fmt) - struct.calcsize('!bH')
+    session_status = 0
+    client_id = 0
+    imei = '0'*15
+    if mt_packet[0] is not None:
+        print mt_packet
+        session_status = len(mt_messages)
+        client_id = mt_packet[0][0]
+        imei = mt_packet[0][1]
+    else:
+        session_status = -7 # violation of MT DirectIP protocol error
+
+
+    # MT Confirmation Message IEI
+    # MT Confirmation Message Length
+    # Unique Client Message ID
+    # IMEI (User ID)
+    # Auto ID Reference
+    # MT Message Status
+    auto_id = random.getrandbits(32)
+    confirm = struct.pack(confirm_fmt, confirm_iei, confirm_length, client_id, imei, auto_id, session_status)
+    
+    protocol_rev_no = 1    
+    overall_msg_length = len(confirm)
+    preheader = struct.pack('!bH', protocol_rev_no, overall_msg_length)
+    return preheader + confirm

--- a/setup.py
+++ b/setup.py
@@ -3,5 +3,5 @@ setup(name='virtual_iridium',
       version='1.0',
       package_dir={'virtual_iridium': 'python'},
       packages=['virtual_iridium'],
-      scripts=['python/Iridium9602.py', 'python/iridium_mo_forward_server.py', 'python/iridium_mt_forward_server.py']
+      scripts=['python/Iridium9602.py', 'python/iridium_mo_forward_server.py', 'python/iridium_mt_forward_server.py', 'python/iridium_rudics_shore_connection.py']
       )

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,7 @@
+from distutils.core import setup
+setup(name='virtual_iridium',
+      version='1.0',
+      package_dir={'virtual_iridium': 'python'},
+      packages=['virtual_iridium'],
+      scripts=['python/Iridium9602.py', 'python/mo_forward_server.py', 'python/mt_forward_server.py']
+      )

--- a/setup.py
+++ b/setup.py
@@ -3,5 +3,5 @@ setup(name='virtual_iridium',
       version='1.0',
       package_dir={'virtual_iridium': 'python'},
       packages=['virtual_iridium'],
-      scripts=['python/Iridium9602.py', 'python/mo_forward_server.py', 'python/mt_forward_server.py']
+      scripts=['python/Iridium9602.py', 'python/iridium_mo_forward_server.py', 'python/iridium_mt_forward_server.py']
       )


### PR DESCRIPTION
Added support for the DirectIP version of Iridium SBD to Iridium9206.py. Tested on Goby (http://gobysoft.org/doc/2.0/) driver for Iridium9523 (essentially the same SBD protocol). 

Removed list_serial_ports method which requires pyserial 2.7 (I need to run with 2.6).

Also added several more support scripts (optional if you're only using a single SBD phone and no RUDICS support). In conjunction with ATDuck (https://github.com/nandhp/atduck) these allow you to create a complete SBD & RUDICS simulator that works like Iridium's real system:
- iridium_mo_forward_server.py - Allows you to simultaneously use a Hayes modem emulator (I used https://github.com/nandhp/atduck) and the Iridium9602.py simulator to support both Iridium RUDICS and SDB.
- iridium_mt_forward_server.py - Allows you to simulate sending MT SBD DirectIP packets to multiple Iridium9602.py simulators. This is the same as the hardware works (Iridium provides a single MT server.)
- iridium_rudics_shore_connection.py - Mimics the Iridium shore side connection for RUDICS by connecting to a Hayes modem emulator on one end and making a TCP connection on the other.